### PR TITLE
Run clang-format.

### DIFF
--- a/src/simple_tokenizer_test.cc
+++ b/src/simple_tokenizer_test.cc
@@ -21,7 +21,7 @@ TEST(SimpleTokenizer, BasicIdentifiers) {
       "`some_macro endmodule",
   };
   SimpleTokenizer tk;
-  for (auto &line :lines) {
+  for (auto &line : lines) {
     tk.ProcessLine(line);
   }
   EXPECT_EQ(tk.Comments(0).size(), 0);

--- a/src/text_input.h
+++ b/src/text_input.h
@@ -1,9 +1,9 @@
 #pragma once
 
-#include <string>
 #include <deque>
 #include <functional>
 #include <ncurses.h>
+#include <string>
 
 namespace sv {
 

--- a/src/tree_panel.cc
+++ b/src/tree_panel.cc
@@ -66,10 +66,9 @@ void TreePanel::Draw() {
           mvwaddch(w_, y, x, '>');
         } else {
           if (j >= type_pos && j < type_pos + type_name.size()) {
-            const auto color =
-                item->ErrType()
-                    ? kHierErrPair
-                    : item->AltType() ? kHierOtherPair : kHierTypePair;
+            const auto color = item->ErrType()   ? kHierErrPair
+                               : item->AltType() ? kHierOtherPair
+                                                 : kHierTypePair;
             SetColor(w_, color);
           } else if (j >= inst_pos) {
             if (show_search && j == search_pos) {

--- a/src/uhdm_utils.cc
+++ b/src/uhdm_utils.cc
@@ -18,12 +18,12 @@
 #include <uhdm/port.h>
 #include <uhdm/process_stmt.h>
 #include <uhdm/ref_obj.h>
+#include <uhdm/sv_vpi_user.h>
 #include <uhdm/task_call.h>
 #include <uhdm/tf_call.h>
 #include <uhdm/uhdm_vpi_user.h>
-#include <uhdm/while_stmt.h>
-#include <uhdm/sv_vpi_user.h>
 #include <uhdm/vpi_user.h>
+#include <uhdm/while_stmt.h>
 
 namespace sv {
 namespace {

--- a/src/uhdm_utils.h
+++ b/src/uhdm_utils.h
@@ -7,14 +7,17 @@ namespace sv {
 
 // Helper utilities to wrangle a UHDM design.
 
-// Returns true if the item is something that might be found in waves and/or be considered a net.
+// Returns true if the item is something that might be found in waves and/or be
+// considered a net.
 bool IsTraceable(const UHDM::any *item);
 
-// Trace the drivers or loads of a given net (or do nothing if the item isn't a net).
+// Trace the drivers or loads of a given net (or do nothing if the item isn't a
+// net).
 void GetDriversOrLoads(const UHDM::any *item, bool drivers,
                        std::vector<const UHDM::any *> &list);
 
-// Find the containg module of any item, moving up through generate blocks if necessary.
+// Find the containg module of any item, moving up through generate blocks if
+// necessary.
 const UHDM::module *GetContainingModule(const UHDM::any *item);
 
 // Find the containing scope (module or genblock) of any item.

--- a/src/waves_panel.cc
+++ b/src/waves_panel.cc
@@ -1111,8 +1111,8 @@ void WavesPanel::AddGroup() {
 }
 
 bool WavesPanel::Modal() const {
-  return rename_item_ != nullptr || inputting_time_ || 
-         showing_path_ || inputting_open_ || inputting_save_;
+  return rename_item_ != nullptr || inputting_time_ || showing_path_ ||
+         inputting_open_ || inputting_save_;
 }
 
 std::vector<Tooltip> WavesPanel::Tooltips() const {


### PR DESCRIPTION
Thus we have a clean baseline once we enable it in the CI.

Signed-off-by: Henner Zeller <hzeller@google.com>