### PR TITLE
Start a CI: check formatting of source files.

### DIFF
--- a/.github/bin/run-clang-format.sh
+++ b/.github/bin/run-clang-format.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+FORMAT_OUT=${TMPDIR:-/tmp}/clang-format-diff.out
+
+# Run on all files.
+find src/ -name "*.h" -o -name "*.cc" | xargs -P2 clang-format-11 -i
+
+# Check if we got any diff
+git diff > ${FORMAT_OUT}
+
+if [ -s ${FORMAT_OUT} ]; then
+   echo "Style not matching; please run .github/bin/run-clang-format.sh"
+   cat ${FORMAT_OUT}
+   exit 1
+fi
+
+exit 0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+name: CI
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  CodeFormatting:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Install Dependencies
+      run: |
+        sudo apt-get install clang-format
+
+    - name: Run formatting style check
+      run: ./.github/bin/run-clang-format.sh


### PR DESCRIPTION
The build and test CI is a bit more involved with first
installing surelog and such, so let's start simple.

Signed-off-by: Henner Zeller <hzeller@google.com>