### PR TITLE
Add starting point to run clang-tidy.

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,40 @@
+---
+# readability-make-member-function-const is great, but it also suggests that
+#    in cases where we return a non-const pointer. So good to check, not by
+#    default.
+#
+# readability-qualified-auto is useful in general, however it suggests
+#    to convert iterators (e.g. std::string_view::begin()) to the pointer it
+#    returns; however since the iterator is implementation defined, this is not
+#    a valid assertion. Running the check every now and then manually and
+#    fixing all the non-iterator cases is useful though. Off by default.
+#
+# Some other not entirely useful checks are also disabled, to be revisited
+# later.
+##
+Checks: >
+  clang-diagnostic-*,clang-analyzer-*,
+  abseil-*,
+  readability-*,
+  -readability-make-member-function-const,
+  -readability-qualified-auto,
+  -readability-braces-around-statements,
+  -readability-magic-numbers,
+  -readability-implicit-bool-conversion,
+  -readability-isolate-declaration,
+  -readability-else-after-return,
+  google-*,
+  -google-readability-braces-around-statements,
+  -google-readability-todo,
+  -google-readability-casting,
+  performance-*,
+  bugprone-*,
+  -bugprone-narrowing-conversions,
+  modernize-use-override,
+  misc-*,
+  -misc-non-private-member-variables-in-classes,
+
+WarningsAsErrors: ''
+HeaderFilterRegex: ''
+AnalyzeTemporaryDtors: false
+...

--- a/.github/bin/run-clang-tidy.sh
+++ b/.github/bin/run-clang-tidy.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+set -u
+
+TMPDIR="${TMPDIR:-/tmp}"
+
+readonly PARALLEL_COUNT=$(nproc)
+readonly FILES_PER_INVOCATION=5
+
+readonly FILES_TO_PROCESS=${TMPDIR}/clang-tidy-files.list
+readonly TIDY_OUT=${TMPDIR}/clang-tidy.out
+
+# Using clang-tidy-11 as it is the last one still checking for
+# google-runtime-references, non-const references in parameters - which is
+# better than the later relaxed Google styleguide rules in hzeller's opinion.
+readonly CLANG_TIDY=clang-tidy-11
+hash ${CLANG_TIDY} || exit 2  # make sure it is installed.
+
+echo ::group::Build compilation database
+
+# TODO(hzeller): this might need modification if Surelog installed elsewhere.
+cmake -B build .
+
+find src -name "*.h" -o -name "*.cc" > ${FILES_TO_PROCESS}
+
+echo "::endgroup::"
+
+echo "::group::Run ${CLANG_TIDY} on $(wc -l < ${FILES_TO_PROCESS}) files"
+
+cat ${FILES_TO_PROCESS} \
+    | xargs -P${PARALLEL_COUNT} -n ${FILES_PER_INVOCATION} -- \
+            ${CLANG_TIDY} --quiet 2>/dev/null \
+            > ${TIDY_OUT}.tmp
+
+# Only modify at the end, so we can inspect the file manually while a new run
+# of this script is in progress.
+mv ${TIDY_OUT}.tmp ${TIDY_OUT}
+
+cat ${TIDY_OUT}
+
+echo "::endgroup::"
+
+if [ -s ${TIDY_OUT} ]; then
+
+    # Tidy results were non-empty. Put a summary into a separate group.
+    echo "::group::Summary"
+    # Give a nice overview of how many counts of which problem found.
+    sed 's|\(.*\)\(\[[a-zA-Z.-]*\]$\)|\2|p;d' < ${TIDY_OUT} | sort | uniq -c | sort -n
+    echo "::endgroup::"
+
+    echo "::error::There were clang-tidy warnings. Please fix"
+    exit 1
+fi
+
+echo "No clang-tidy complaints :-)"
+exit 0


### PR DESCRIPTION
It can be manually invoked with
  .github/bin/run-clang-tidy.sh

Right now, this is not wired up to the CI yet, as
some initial cleanup would be needed.

Even if not wired up to CI, the clangd language server
will help point out issues directly in the editor.

These are the count and type of current findings
(of course, .clang-tidy should also be changed to
taste)
      1 [abseil-faster-strsplit-delimiter]
      1 [abseil-string-find-str-contains]
      1 [bugprone-string-integer-assignment]
      1 [clang-analyzer-core.NullDereference]
      1 [misc-redundant-expression]
      1 [readability-delete-null-pointer]
      1 [readability-redundant-control-flow]
      2 [bugprone-branch-clone]
      2 [bugprone-parent-virtual-call]
      2 [misc-unused-parameters]
      2 [performance-for-range-copy]
      2 [performance-unnecessary-copy-initialization]
      3 [google-explicit-constructor]
      3 [performance-inefficient-string-concatenation]
      3 [performance-unnecessary-value-param]
      3 [readability-redundant-string-init]
      3 [readability-uppercase-literal-suffix]
      5 [abseil-string-find-startswith]
      5 [misc-no-recursion]
      5 [modernize-use-override]
      5 [readability-container-size-empty]
      8 [google-runtime-references]
      9 [misc-throw-by-value-catch-by-reference]

Signed-off-by: Henner Zeller <h.zeller@acm.org>