### PR TITLE
Add missing include.

### DIFF
--- a/src/workspace.cc
+++ b/src/workspace.cc
@@ -1,7 +1,9 @@
 #include "workspace.h"
 #include "uhdm_utils.h"
 #include "utils.h"
+
 #include <algorithm>
+#include <stack>
 #include <stdexcept>
 #include <surelog/surelog.h>
 #include <uhdm/ElaboratorListener.h>


### PR DESCRIPTION
Stack was missing in the includes and newer versions of
surelog don't include that anymore transitively.

Signed-off-by: Henner Zeller <h.zeller@acm.org>